### PR TITLE
Added message attribute feature

### DIFF
--- a/lib/logstash/outputs/sns.rb
+++ b/lib/logstash/outputs/sns.rb
@@ -109,7 +109,6 @@ class LogStash::Outputs::Sns < LogStash::Outputs::Base
     }
     if message_attribute != NO_MESSAGE_ATTRIBUTES and message_attribute!=nil
       publish_body[:message_attributes] = message_attribute
-    else
       @logger.debug? && @logger.debug("Sending event to SNS topic [#{arn}] with subject [#{trunc_subj}] and message: #{trunc_msg}")
     end
     @sns.publish(publish_body)
@@ -163,6 +162,8 @@ class LogStash::Outputs::Sns < LogStash::Outputs::Base
               :data_type => "String.Array",
               :string_value => value
           }
+        else
+          @logger.error("Non string array is being sent in message attributes. Message Attributes: #{sns_message_attribute}")
         end
       end
     end
@@ -179,6 +180,7 @@ class LogStash::Outputs::Sns < LogStash::Outputs::Base
       return false
     end
   rescue JSON::ParserError => e
+    @logger.error("Error while parsing message attributes. Message Attributes: #{e}")
     return false
   end
 

--- a/lib/logstash/outputs/sns.rb
+++ b/lib/logstash/outputs/sns.rb
@@ -34,12 +34,13 @@ require "logstash/util/unicode_trimmer"
 class LogStash::Outputs::Sns < LogStash::Outputs::Base
   include LogStash::PluginMixins::AwsConfig::V2
 
-  MAX_SUBJECT_SIZE_IN_CHARACTERS  = 100
-  MAX_MESSAGE_SIZE_IN_BYTES       = 32768
+  MAX_SUBJECT_SIZE_IN_CHARACTERS = 100
+  MAX_MESSAGE_SIZE_IN_BYTES = 32768
   NO_SUBJECT = "NO SUBJECT"
+  NO_MESSAGE_ATTRIBUTES = "NO_MESSAGE_ATTRIBUTES"
 
   config_name "sns"
-  
+
   concurrency :shared
 
   # Optional ARN to send messages to. If you do not set this you must
@@ -55,6 +56,7 @@ class LogStash::Outputs::Sns < LogStash::Outputs::Base
   config :publish_boot_message_arn, :validate => :string
 
   public
+
   def register
     require "aws-sdk-resources"
 
@@ -63,17 +65,18 @@ class LogStash::Outputs::Sns < LogStash::Outputs::Base
     publish_boot_message_arn()
 
     @codec.on_event do |event, encoded|
-      send_sns_message(event_arn(event), event_subject(event), encoded)
+      send_sns_message(event_arn(event), event_subject(event), encoded, event_message_attributes(event))
     end
   end
 
   public
+
   def receive(event)
-    
+
 
     if (sns_msg = event.get("sns_message"))
       if sns_msg.is_a?(String)
-        send_sns_message(event_arn(event), event_subject(event), sns_msg)
+        send_sns_message(event_arn(event), event_subject(event), sns_msg, event_message_attributes(event))
       else
         @codec.encode(sns_msg)
       end
@@ -83,31 +86,37 @@ class LogStash::Outputs::Sns < LogStash::Outputs::Base
   end
 
   private
+
   def publish_boot_message_arn
     # Try to publish a "Logstash booted" message to the ARN provided to
     # cause an error ASAP if the credentials are bad.
     if @publish_boot_message_arn
-      send_sns_message(@publish_boot_message_arn, 'Logstash booted', 'Logstash successfully booted')
+      send_sns_message(@publish_boot_message_arn, 'Logstash booted', 'Logstash successfully booted', NO_MESSAGE_ATTRIBUTES,)
     end
   end
 
   private
-  def send_sns_message(arn, subject, message)
+
+  def send_sns_message(arn, subject, message, message_attribute)
     raise ArgumentError, 'An SNS ARN is required.' unless arn
 
     trunc_subj = LogStash::Util::UnicodeTrimmer.trim_bytes(subject, MAX_SUBJECT_SIZE_IN_CHARACTERS)
     trunc_msg = LogStash::Util::UnicodeTrimmer.trim_bytes(message, MAX_MESSAGE_SIZE_IN_BYTES)
-
-    @logger.debug? && @logger.debug("Sending event to SNS topic [#{arn}] with subject [#{trunc_subj}] and message: #{trunc_msg}")
-
-    @sns.publish({
-                   :topic_arn => arn,
-                   :subject => trunc_subj,
-                   :message => trunc_msg
-                 })
+    publish_body = {
+        :topic_arn => arn,
+        :subject => trunc_subj,
+        :message => trunc_msg
+    }
+    if message_attribute != NO_MESSAGE_ATTRIBUTES and message_attribute!=nil
+      publish_body[:message_attributes] = message_attribute
+    else
+      @logger.debug? && @logger.debug("Sending event to SNS topic [#{arn}] with subject [#{trunc_subj}] and message: #{trunc_msg}")
+    end
+    @sns.publish(publish_body)
   end
 
   private
+
   def event_subject(event)
     sns_subject = event.get("sns_subject")
     if sns_subject.is_a?(String)
@@ -122,6 +131,59 @@ class LogStash::Outputs::Sns < LogStash::Outputs::Base
   end
 
   private
+
+  def event_message_attributes(event)
+    sns_message_attribute = event.get("sns_message_attribute")
+    if valid_json?(sns_message_attribute)
+      return create_message_attribute_body(sns_message_attribute)
+    else
+      return NO_MESSAGE_ATTRIBUTES
+    end
+  end
+
+  private
+
+  def create_message_attribute_body(sns_message_attribute)
+    message_attribute_in_json = JSON.parse(sns_message_attribute)
+    message_attributes = {}
+    message_attribute_in_json.each do |key, value|
+      if value.is_a?(String)
+        message_attributes[key] = {
+            :data_type => "String",
+            :string_value => value
+        }
+      elsif value.is_a?(Numeric)
+        message_attributes[key] = {
+            :data_type => "Number",
+            :string_value => value
+        }
+      elsif value.is_a?(Array)
+        if value.all? {|i| i.is_a?(String)}
+          message_attributes[key] = {
+              :data_type => "String.Array",
+              :string_value => value
+          }
+        end
+      end
+    end
+    return message_attributes
+  end
+
+  private
+
+  def valid_json?(json)
+    unless json.nil? || json.empty?
+      JSON.parse(json)
+      return true
+    else
+      return false
+    end
+  rescue JSON::ParserError => e
+    return false
+  end
+
+  private
+
   def event_arn(event)
     event.get("sns") || @arn
   end

--- a/spec/outputs/sns_spec.rb
+++ b/spec/outputs/sns_spec.rb
@@ -194,5 +194,14 @@ describe LogStash::Outputs::Sns do
       expect(response["channel"][:data_type]).to eql("String.Array")
       expect(response["channel"][:string_value]).to eql(["product channel", "Test channel"])
     end
+
+    it "Testing multiple string message attributes" do
+      response = subject.send(:create_message_attribute_body, '{"channel": "product channel", "severity": 5}')
+      expect(response["channel"][:data_type]).to eql("String")
+      expect(response["channel"][:string_value]).to eql("product channel")
+      expect(response["severity"][:data_type]).to eql("Number")
+      expect(response["severity"][:string_value]).to eql(5)
+
+    end
   end
 end

--- a/spec/outputs/sns_spec.rb
+++ b/spec/outputs/sns_spec.rb
@@ -9,7 +9,9 @@ require "aws-sdk" # TODO: Why is this not automatically brought in by the aws_co
 describe LogStash::Outputs::Sns do
   let(:arn) { "arn:aws:sns:us-east-1:999999999:logstash-test-sns-topic" }
   let(:sns_subject) { "The Plain in Spain" }
+  let (:default_message_attribute) { "NO_MESSAGE_ATTRIBUTES" }
   let(:sns_message) { "That's where the rain falls, plainly." }
+  let (:sns_message_attribute) {'{"channel": "product channel"}'}
   let(:mock_client) { double("Aws::SNS::Client") }
   let(:instance) {
     allow(Aws::SNS::Client).to receive(:new).and_return(mock_client)
@@ -33,15 +35,15 @@ describe LogStash::Outputs::Sns do
 
     shared_examples("publishing correctly") do
       it "should send a message to the correct ARN if the event has 'arn' set" do
-        expect(subject).to have_received(:send_sns_message).with(arn, anything, anything)
+        expect(subject).to have_received(:send_sns_message).with(arn, anything, anything, default_message_attribute)
       end
 
       it "should send the message" do
-        expect(subject).to have_received(:send_sns_message).with(anything, anything, expected_message)
+        expect(subject).to have_received(:send_sns_message).with(anything, anything, expected_message, default_message_attribute)
       end
 
       it "should send the subject" do
-        expect(subject).to have_received(:send_sns_message).with(anything, expected_subject, anything)
+        expect(subject).to have_received(:send_sns_message).with(anything, expected_subject, anything, default_message_attribute)
       end
     end
 
@@ -95,7 +97,8 @@ describe LogStash::Outputs::Sns do
       {
         :topic_arn => arn,
         :subject => sns_subject,
-        :message => sns_message
+        :message => sns_message,
+        :message_attributes => sns_message_attribute
       }
     }
     let(:long_message) { "A" * (LogStash::Outputs::Sns::MAX_MESSAGE_SIZE_IN_BYTES + 1) }
@@ -110,7 +113,7 @@ describe LogStash::Outputs::Sns do
 
     it "should send a well formed message through to SNS" do
       expect(mock_client).to receive(:publish).with(good_publish_args)
-      subject.send(:send_sns_message, arn, sns_subject, sns_message)
+      subject.send(:send_sns_message, arn, sns_subject, sns_message, sns_message_attribute)
     end
 
     it "should attempt to publish a boot message" do
@@ -127,7 +130,7 @@ describe LogStash::Outputs::Sns do
                                expect(args[:message].bytesize).to eql(max_size)
                              }
 
-      subject.send(:send_sns_message, arn, sns_subject, long_message)
+      subject.send(:send_sns_message, arn, sns_subject, long_message, nil)
     end
 
     it "should truncate long subjects before sending" do
@@ -136,7 +139,60 @@ describe LogStash::Outputs::Sns do
                                expect(args[:subject].bytesize).to eql(max_size)
                              }
 
-      subject.send(:send_sns_message, arn, long_subject, sns_message)
+      subject.send(:send_sns_message, arn, long_subject, sns_message, nil)
+    end
+  end
+
+  describe "Consume message attributes" do
+
+    it "Testing No message attributes" do
+      event = LogStash::Event.new()
+      response = subject.send(:event_message_attributes, event)
+      expect(response).to eql(default_message_attribute)
+    end
+
+    it "Testing String message attributes" do
+      event = LogStash::Event.new("sns_message_attribute" => '{"channel": "product channel"}')
+      response = subject.send(:event_message_attributes, event)
+      expect(response["channel"][:data_type]).to eql("String")
+      expect(response["channel"][:string_value]).to eql("product channel")
+    end
+
+    it "Testing Number message attributes" do
+      event = LogStash::Event.new("sns_message_attribute" => '{"channel": 123}')
+      response = subject.send(:event_message_attributes, event)
+      expect(response["channel"][:data_type]).to eql("Number")
+      expect(response["channel"][:string_value]).to eql(123)
+    end
+
+    it "Testing String array message attributes" do
+      event = LogStash::Event.new("sns_message_attribute" => '{"channel": ["product channel", "Test channel"]}')
+      response = subject.send(:event_message_attributes, event)
+
+      expect(response["channel"][:data_type]).to eql("String.Array")
+      expect(response["channel"][:string_value]).to eql(["product channel", "Test channel"])
+    end
+  end
+
+
+  describe "creating message attributes body for AWS SDK" do
+
+    it "Testing String message attributes" do
+      response = subject.send(:create_message_attribute_body, '{"channel": "product channel"}')
+      expect(response["channel"][:data_type]).to eql("String")
+      expect(response["channel"][:string_value]).to eql("product channel")
+    end
+
+    it "Testing Number message attributes" do
+      response = subject.send(:create_message_attribute_body, '{"channel": 123}')
+      expect(response["channel"][:data_type]).to eql("Number")
+      expect(response["channel"][:string_value]).to eql(123)
+    end
+
+    it "Testing String array message attributes" do
+      response = subject.send(:create_message_attribute_body, '{"channel": ["product channel", "Test channel"]}')
+      expect(response["channel"][:data_type]).to eql("String.Array")
+      expect(response["channel"][:string_value]).to eql(["product channel", "Test channel"])
     end
   end
 end


### PR DESCRIPTION
- In order to support SNS subscription filter policy, we need to add a support for sending message attributes along with the message.

https://docs.aws.amazon.com/sns/latest/dg/sns-subscription-filter-policies.html

Thanks for contributing to Logstash! If you haven't already signed our CLA, here's a handy link: https://www.elastic.co/contributor-agreement/
